### PR TITLE
Add maven prerequisite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,10 @@
 
   </properties>
 
+  <prerequisites>
+    <maven>${maven.min.version}</maven>
+  </prerequisites>
+
   <build>
 
     <pluginManagement>


### PR DESCRIPTION
If you add the maven prerequisite entry the versions plugin can easily say which plugin can be upgraded for this version : mvn org.codehaus.mojo:versions-maven-plugin:1.3.1:display-plugin-updates
