### PR TITLE
Updated version of enforcer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <version.ear.plugin>2.4.2</version.ear.plugin>
     <version.eclipse.plugin>2.8</version.eclipse.plugin>
     <version.ejb.plugin>2.2.1</version.ejb.plugin>
-    <version.enforcer.plugin>1.0</version.enforcer.plugin>
+    <version.enforcer.plugin>1.1</version.enforcer.plugin>
     <version.failsafe.plugin>2.12</version.failsafe.plugin>
     <version.findbugs.plugin>2.2</version.findbugs.plugin>
     <version.gpg.plugin>1.4</version.gpg.plugin>


### PR DESCRIPTION
The maven enforcer plugin needed to be updated to 1.1. This is in order to allow for the use of pulling down of SNAPSHOTS from the JBoss Nexus repository so that they can be used for testing purposes.
