### PR TITLE
Deal with tools.jar problems on OSX JDK7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,11 +151,25 @@
     <!-- maven-assembly-plugin -->
     <sourceReleaseAssemblyDescriptor>source-release</sourceReleaseAssemblyDescriptor>
 
+    <!-- tools.jar location, this needs to be overriden on OSX -->
+    <com.sun.tools.path>${java.home}/../lib/tools.jar</com.sun.tools.path>
   </properties>
 
   <prerequisites>
     <maven>${maven.min.version}</maven>
   </prerequisites>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.sun</groupId>
+        <artifactId>tools</artifactId>
+        <scope>system</scope>
+        <version>1.6</version>
+        <systemPath>${com.sun.tools.path}</systemPath>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
 
@@ -752,6 +766,18 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <profile>
+      <id>os-x.tools.jar.override</id>
+      <activation>
+        <file>
+          <exists>${java.home}/bundle/Classes/classes.jar</exists>
+        </file>
+      </activation>
+      <properties>
+        <com.sun.tools.path>${java.home}/bundle/Classes/classes.jar</com.sun.tools.path>
+      </properties>
     </profile>
 
   </profiles>


### PR DESCRIPTION
Some OSX JDK's use classes.jar instead of tools.jar, and some don't. JDK's that use classes.jar will refuse to build projects that pull in tools.jar (e.g. because of a byteman dependency) unless the project has this fix. 

Rather than adding this to every project as these problems are discovered I thought it might make more sense to add this to the parent pom. 
