### PR TITLE
Setting java.io.tmpdir to ${project.build.directory}

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -532,6 +532,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${version.surefire.plugin}</version>
+          <configuration>
+            <systemProperties>
+              <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+            </systemProperties>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This ensures that tests that create temp files using File.createTempFile (or the java.io.tmpdir system property) will not create files outside the build directory.
