### PR TITLE
Updated buildnumber plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <version.apt.plugin>1.0-alpha-5</version.apt.plugin>
     <version.assembly.plugin>2.4</version.assembly.plugin>
     <version.buildhelper.plugin>1.8</version.buildhelper.plugin>
-    <version.buildnumber.plugin>1.2</version.buildnumber.plugin>
+    <version.buildnumber.plugin>1.3</version.buildnumber.plugin>
     <version.bundle.plugin>2.3.7</version.bundle.plugin>
     <version.checkstyle.plugin>2.11</version.checkstyle.plugin>
     <version.clean.plugin>2.5</version.clean.plugin>


### PR DESCRIPTION
Buildnumber plugin 1.3 resolves Git branches correctly (http://jira.codehaus.org/browse/MBUILDNUM-66)
