### PR TITLE
Fix tarLongFileFormat renamed to tarLongFileMode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -713,7 +713,7 @@
                   <descriptorRefs>
                     <descriptorRef>${sourceReleaseAssemblyDescriptor}</descriptorRef>
                   </descriptorRefs>
-                  <tarLongFileFormat>gnu</tarLongFileFormat>
+                  <tarLongFileMode>gnu</tarLongFileMode>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
See https://maven.apache.org/plugins/maven-assembly-plugin/assembly-mojo.html#tarLongFileMode for reference

Unless I am missing something..