### PR TITLE
Allow source/target compiler version for tests to be configured separately

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,15 +130,17 @@
     <!-- maven-compiler-plugin -->
     <maven.compiler.target>1.7</maven.compiler.target>
     <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.testTarget>1.7</maven.compiler.testTarget>
+    <maven.compiler.testSource>1.7</maven.compiler.testSource>
 
     <!--
-        Options to override the compiler arguments directly on the compiler arument line to separate between what
+        Options to override the compiler arguments directly on the compiler argument line to separate between what
         the IDE understands as the source level and what the Maven compiler actually use.
     -->
     <maven.compiler.argument.target>${maven.compiler.target}</maven.compiler.argument.target>
     <maven.compiler.argument.source>${maven.compiler.source}</maven.compiler.argument.source>
-    <maven.compiler.argument.testTarget>${maven.compiler.target}</maven.compiler.argument.testTarget>
-    <maven.compiler.argument.testSource>${maven.compiler.source}</maven.compiler.argument.testSource>
+    <maven.compiler.argument.testTarget>${maven.compiler.testTarget}</maven.compiler.argument.testTarget>
+    <maven.compiler.argument.testSource>${maven.compiler.testSource}</maven.compiler.argument.testSource>
 
     <!-- maven-enforcer-plugin -->
     <maven.min.version>3.0.4</maven.min.version>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,8 @@
     -->
     <maven.compiler.argument.target>${maven.compiler.target}</maven.compiler.argument.target>
     <maven.compiler.argument.source>${maven.compiler.source}</maven.compiler.argument.source>
+    <maven.compiler.argument.testTarget>${maven.compiler.target}</maven.compiler.argument.testTarget>
+    <maven.compiler.argument.testSource>${maven.compiler.source}</maven.compiler.argument.testSource>
 
     <!-- maven-enforcer-plugin -->
     <maven.min.version>3.0.4</maven.min.version>
@@ -286,6 +288,8 @@
             <showWarnings>true</showWarnings>
             <source>${maven.compiler.argument.source}</source>
             <target>${maven.compiler.argument.target}</target>
+            <testSource>${maven.compiler.argument.testSource}</testSource>
+            <testTarget>${maven.compiler.argument.testTarget}</testTarget>
             <compilerArgs>
               <arg>-Xlint:unchecked</arg>
             </compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -130,8 +130,8 @@
     <!-- maven-compiler-plugin -->
     <maven.compiler.target>1.7</maven.compiler.target>
     <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.testTarget>1.7</maven.compiler.testTarget>
-    <maven.compiler.testSource>1.7</maven.compiler.testSource>
+    <maven.compiler.testTarget>${maven.compiler.target}</maven.compiler.testTarget>
+    <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>
 
     <!--
         Options to override the compiler arguments directly on the compiler argument line to separate between what


### PR DESCRIPTION
Added `maven.compiler.argument.testTarget` and `maven.compiler.argument.testSource`