### PR TITLE
Upgrade maven-bundle-plugin to 3.0.1 which fixes FELIX-4882

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <version.assembly.plugin>2.5.5</version.assembly.plugin>
     <version.buildhelper.plugin>1.9.1</version.buildhelper.plugin>
     <version.buildnumber.plugin>1.3</version.buildnumber.plugin>
-    <version.bundle.plugin>2.5.4</version.bundle.plugin>
+    <version.bundle.plugin>3.0.1</version.bundle.plugin>
     <version.checkstyle.plugin>2.15</version.checkstyle.plugin>
     <version.clean.plugin>2.6.1</version.clean.plugin>
     <version.clover2.plugin>4.0.4</version.clover2.plugin>


### PR DESCRIPTION
 * version 2.5.4 has nasty bug which results in forked executions
   for the bundle-plugin goals
 * there is no 2.5.5 version, so 3.0.x seems to be the best choice
 * see https://issues.apache.org/jira/browse/FELIX-4882