### PR TITLE
Update apache-source-release-assembly-descriptor to 1.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -710,7 +710,7 @@
               <dependency>
                 <groupId>org.apache.apache.resources</groupId>
                 <artifactId>apache-source-release-assembly-descriptor</artifactId>
-                <version>1.0.4</version>
+                <version>1.0.5</version>
               </dependency>
             </dependencies>
             <executions>


### PR DESCRIPTION
Release 1.0.5
-------------

* Use &lt;tarLongFileMode&gt; instead of &lt;tarLongFileFormat&gt; which has never worked
  for maven-assembly-plugin
* MASFRES-9 Add pre-defined descriptor in
  apache-source-release-assembly-descriptor for tarball-only