### PR TITLE
fix: javadoc plugin uses additionalOptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -464,6 +464,7 @@
               </manifestEntries>
             </archive>
             <additionalparam>${javadoc.additional.params}</additionalparam>
+            <additionalOptions>${javadoc.additional.params}</additionalOptions>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
`additionalparam` has be removed in favor of `additionalOptions` - thus using `-Xdoclint:none` with this parent pom is causing the build to fail regardless.