### PR TITLE
Add jboss-public-repository as a pluginRepository

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -842,6 +842,22 @@
     </profile>
 
   </profiles>
+  
+  <!-- Some plugins are available in the jboss repository only -->
+  <pluginRepositories>
+    <pluginRepository>
+      <id>jboss-public-repository</id>
+      <name>JBoss Public Maven Repository</name>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <layout>default</layout>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 
   <distributionManagement>
     <repository>


### PR DESCRIPTION
Because some plugins are available in the JBoss repository, the pluginRepository is required to avoid build errors when using this parent pom