### PR TITLE
Add the tools.jar to the class path for Java 8 tests

### DIFF
--- a/mr-jar/pom.xml
+++ b/mr-jar/pom.xml
@@ -101,6 +101,9 @@
                                 </goals>
                                 <configuration>
                                     <jvm>${java8.home}/bin/java</jvm>
+                                    <additionalClasspathElements>
+                                        <additionalClasspathElement>${java8.home}/lib/tools.jar</additionalClasspathElement>
+                                    </additionalClasspathElements>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
This is not required to be merged. However it _may_ require tests that use agent, such as byteman, to add a profile which adds the `tools.jar` to the class path for Java 8 tests if a higher JDK is being used. That's not really a big inconvenience so I'm fine either way if this makes it or not. I just had the change locally so I thought I may as well put it out there :)