### PR TITLE
Upgrade Sonar plugin to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
       <version.resources.plugin>3.1.0</version.resources.plugin>
       <version.shade.plugin>3.1.1</version.shade.plugin>
       <version.site.plugin>3.7.1</version.site.plugin>
-      <version.sonar.plugin>3.4.0.905</version.sonar.plugin>
+      <version.sonar.plugin>3.6.0.1398</version.sonar.plugin>
       <version.source.plugin>3.0.1</version.source.plugin>
       <version.surefire.plugin>2.22.0</version.surefire.plugin>
       <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>


### PR DESCRIPTION
I don't know if there is any specific reason to use 3.4.0.905, but it is almost two years old.