### PR TITLE
Upgrade the site plugin from 3.7.1 to 3.8.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
       <version.release.plugin>2.5.3</version.release.plugin>
       <version.resources.plugin>3.1.0</version.resources.plugin>
       <version.shade.plugin>3.1.1</version.shade.plugin>
-      <version.site.plugin>3.7.1</version.site.plugin>
+      <version.site.plugin>3.8.2</version.site.plugin>
       <version.sonar.plugin>3.6.0.1398</version.sonar.plugin>
       <version.source.plugin>3.0.1</version.source.plugin>
       <version.surefire.plugin>2.22.0</version.surefire.plugin>


### PR DESCRIPTION
This is required for newer versions of doxia for Maven plugins. It's not necessarily required, but just allows projects not to have to override the version.