### PR TITLE
Surefire: use systemPropertyVariables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -582,9 +582,9 @@
             <version>${version.surefire.plugin}</version>
             <configuration>
               <trimStackTrace>false</trimStackTrace>
-              <systemProperties>
+              <systemPropertyVariables>
                 <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
-              </systemProperties>
+              </systemPropertyVariables>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
instead of deprecated `systemProperties`

See also:
- https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#systemProperties
- https://github.com/apache/maven-surefire/commit/922afcc54b04868a29ef3159febd85978e1e4587#diff-38e379eb63d7dcd2deb45902b4a494517e4ce54c29913bcf74e7d9243ebb7011R245