### PR TITLE
Upgrade the maven-compiler-plugin to ensure the correct class path is…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
       <version.clean.plugin>3.1.0</version.clean.plugin>
       <version.clover.plugin>4.1.2</version.clover.plugin>
       <version.cobertura.plugin>2.7</version.cobertura.plugin>
-      <version.compiler.plugin>3.8.1-jboss-1</version.compiler.plugin>
+      <version.compiler.plugin>3.8.1-jboss-2</version.compiler.plugin>
       <version.dependency.plugin>3.1.1</version.dependency.plugin>
       <version.deploy.plugin>2.8.2</version.deploy.plugin>
       <version.download.plugin>1.4.2</version.download.plugin>


### PR DESCRIPTION
… used for compiling tests when a module-info.java is present.

Diff: https://github.com/jboss/maven-compiler-plugin/compare/maven-compiler-plugin-3.8.1-jboss-1...maven-compiler-plugin-3.8.1-jboss-2