### PR TITLE
Update maven-compiler-plugin to 3.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
       <version.clean.plugin>3.1.0</version.clean.plugin>
       <version.clover.plugin>4.1.2</version.clover.plugin>
       <version.cobertura.plugin>2.7</version.cobertura.plugin>
-      <version.compiler.plugin>3.8.1</version.compiler.plugin>
+      <version.compiler.plugin>3.10.0</version.compiler.plugin>
       <version.dependency.plugin>3.1.1</version.dependency.plugin>
       <version.deploy.plugin>2.8.2</version.deploy.plugin>
       <version.download.plugin>1.6.7</version.download.plugin>


### PR DESCRIPTION
[Release Notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?version=12345214&styleName=Html&projectId=12317225&Create=Create&atl_token=A5KQ-2QAV-T4JA-FDED_17d2e70caa6bfa64a3fe9c1ff2f279aa0f024817_lin)

Mainly because of https://issues.apache.org/jira/browse/MCOMPILER-413 (which is not listed in the relase notes but _is_ actually fixed).