### PR TITLE
Fix project and scm url in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd" child.project.url.inherit.append.path="false">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -35,7 +35,7 @@
         <url>https://issues.redhat.com/</url>
     </issueManagement>
 
-    <scm>
+    <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
         <connection>scm:git:git@github.com:jboss/jboss-parent-pom.git</connection>
         <developerConnection>scm:git:git@github.com:jboss/jboss-parent-pom.git</developerConnection>
         <url>http://github.com/jboss/jboss-parent-pom</url>


### PR DESCRIPTION
Maven's default behaviour is to append path and artifact id to parent project url for setting child project's url. But this is not helpful because these urls end up in 404s. Similarly, the scm urls are broken. The right behaviour would most likely be to point to just project url.

For instance consider this Quarkus subproject which inherits from this JBoss Parent POM,  https://github.com/quarkusio/quarkus/blob/main/independent-projects/tools/utilities/pom.xml. If you run, `mvn help:effective-pom` in this project, the project url will be resolved to http://www.jboss.org/quarkus-tools-parent/quarkus-devtools-utilities` which is wrong. (There is another issue that the particular independent project doesn't override the url but even with that the path will be wrong for child projects without specifying the attribute)

Thankfully, Maven 3.6.1 introduced some attribute to set the child  project's url to the project url of the parent without modifications. https://maven.apache.org/ref/3.8.4/maven-model/maven.html#:~:text=Description-,child.project.url.inherit.append.path,-String
Therefore, set the child.project.url.inherit.append.path project attribute and various scm attributes to ensure the correct urls are generated.

I have already opened https://github.com/quarkusio/quarkus/pull/23928 for fixing the issue in Quarkus but maybe its better to fix it here because many other projects which require similar fixes would get covered automatically. However, there is a risk of breakage if someone actually wants this behaviour and since this is the parent pom for a wide number of projects the attribute may not be desired here.