### PR TITLE
Increase the minimum required Maven version to 3.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
       <maven.compiler.argument.testSource>${maven.compiler.testSource}</maven.compiler.argument.testSource>
 
       <!-- maven-enforcer-plugin -->
-      <maven.min.version>3.2.5</maven.min.version>
+      <maven.min.version>3.6.2</maven.min.version>
       <jdk.min.version>${maven.compiler.argument.source}</jdk.min.version>
       <insecure.repositories>ERROR</insecure.repositories>
 


### PR DESCRIPTION
Some plugins and dependencies are starting to require higher minimal
Maven version than 3.2.5. Since this is quite an ancient version, it
makes no sense to keep it that old. Also, I believe that many projects
override this default by some higher version already. Let's move this to
3.6.2 now since this is the version used in JBoss EAP/WildFly OpenShift
images. I think it's a nice compromise between being conservative and
moving to latest. This also means minimal required JDK in version 7 [1]
but that should not be any problem either.

[1] https://maven.apache.org/docs/history.html

Fixes #130