### PR TITLE
Bump maven-enforcer-plugin to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
       <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
       <version.ejb.plugin>3.1.0</version.ejb.plugin>
       <version.exec.plugin>3.0.0</version.exec.plugin>
-      <version.enforcer.plugin>3.0.0-M3</version.enforcer.plugin>
+      <version.enforcer.plugin>3.1.0</version.enforcer.plugin>
       <version.findbugs.plugin>3.0.5</version.findbugs.plugin>
       <version.gpg.plugin>1.6</version.gpg.plugin>
       <version.help.plugin>3.2.0</version.help.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
       <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
       <version.ejb.plugin>3.1.0</version.ejb.plugin>
       <version.exec.plugin>3.0.0</version.exec.plugin>
-      <version.enforcer.plugin>3.1.0</version.enforcer.plugin>
+      <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
       <version.findbugs.plugin>3.0.5</version.findbugs.plugin>
       <version.gpg.plugin>1.6</version.gpg.plugin>
       <version.help.plugin>3.2.0</version.help.plugin>


### PR DESCRIPTION
- Release notes at https://github.com/apache/maven-enforcer/releases/tag/enforcer-3.2.1