### PR TITLE
provide correct license info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
 
     <licenses>
         <license>
-            <name>Public Domain</name>
-            <url>http://repository.jboss.org/licenses/cc0-1.0.txt</url>
+            <name>Apache License 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <distribution>repo</distribution>
         </license>
     </licenses>


### PR DESCRIPTION
This POM clearly isn't a Public Domain project and we shouldn't report it as such. The info is consumed at the very least by WildFly/EAP, in cases where a child of jboss-parent-pom doesn't supply its own license the info is taken from here. Granted, we should prefer explicit license declaration in JBoss artifacts but if we've got a fallback it should at least be something else than CC0.