### PR TITLE
Upgrade maven-surefire-plugin and maven-failsafe-plugin to 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
       <version.site.plugin>3.8.2</version.site.plugin>
       <version.sonar.plugin>3.7.0.1746</version.sonar.plugin>
       <version.source.plugin>3.1.0</version.source.plugin>
-      <version.surefire.plugin>2.22.2</version.surefire.plugin>
+      <version.surefire.plugin>3.1.2</version.surefire.plugin>
       <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
       <version.versions.plugin>2.9.0</version.versions.plugin>
       <version.war.plugin>3.2.3</version.war.plugin>


### PR DESCRIPTION
This fixes issue #161 and avoids a maven 3.9 warning.