### PR TITLE
Do not test with `jboss-threads`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,19 +50,6 @@ jobs:
           git diff pom.xml
           mvn -B -ntp install -Djava8.home=${{env.JAVA_HOME_8_X64}} -Djava11.home=${{env.JAVA_HOME_11_X64}}
 
-      - name: Check out JBoss Threads
-        uses: actions/checkout@v2
-        with:
-          repository: jbossas/jboss-threads
-          path: jboss-threads
-
-      - name: Test JBoss Threads with updated parent
-        run: |
-          cd jboss-threads
-          mvn -B -ntp versions:update-parent -DallowSnapshots=true -N
-          git diff pom.xml
-          mvn -B -ntp install -Djava8.home=${{env.JAVA_HOME_8_X64}} -Djava11.home=${{env.JAVA_HOME_11_X64}}
-
       - name: Check out WildFly Maven Plugin
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
It turns out that projects with unstable test suites are highly annoying to test.