### PR TITLE
jboss-parent:40 still manages jdk-misc, but does not define version.jdk-misc anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -774,17 +774,6 @@
 
     </build>
 
-    <dependencyManagement>
-      <dependencies>
-        <dependency>
-          <groupId>org.jboss</groupId>
-          <artifactId>jdk-misc</artifactId>
-          <version>${version.jdk-misc}</version>
-          <scope>provided</scope>
-        </dependency>
-      </dependencies>
-    </dependencyManagement>
-
     <profiles>
 
       <!--


### PR DESCRIPTION
fix #236