### PR TITLE
When `jboss-release` is in effect, release to r.j.o

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -821,7 +821,8 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-deploy-plugin</artifactId>
               <configuration>
-                <updateReleaseInfo>true</updateReleaseInfo>
+                <altReleaseDeploymentRepository>${jboss.releases.repo.id}::${jboss.releases.repo.url}</altReleaseDeploymentRepository>
+                <altSnapshotDeploymentRepository>${jboss.snapshots.repo.id}::${jboss.snapshots.repo.url}</altSnapshotDeploymentRepository>
               </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This takes the place of specifying `distributionManagement`, which was removed in 0070843419c5125.