### PR TITLE
Drop envirnonment-related `MANIFEST.MF` properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -446,10 +446,6 @@
                 <manifestEntries>
                   <Implementation-URL>${project.url}</Implementation-URL>
                   <Java-Version>${java.version}</Java-Version>
-                  <Java-Vendor>${java.vendor}</Java-Vendor>
-                  <Os-Name>${os.name}</Os-Name>
-                  <Os-Arch>${os.arch}</Os-Arch>
-                  <Os-Version>${os.version}</Os-Version>
                   <Scm-Url>${project.scm.url}</Scm-Url>
                   <Scm-Connection>${project.scm.connection}</Scm-Connection>
                   <Scm-Revision>${buildNumber}</Scm-Revision>


### PR DESCRIPTION
This should help to improve build reproducibility.

Fixes #208