### PR TITLE
Remove 'additionalparam' from maven-javadoc-plugin configuration whic…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -483,12 +483,6 @@
                   <Scm-Revision>${buildNumber}</Scm-Revision>
                 </manifestEntries>
               </archive>
-              <!--
-                 Since maven-javadoc-plugin 3.0.0 additionalparam is not not working anymore.
-                 Therefore additionalOptions has been introduced, but old configuration is kept for backward compatibility
-                 in case you are using this parent pom with overwritten version of maven-javadoc-plugin
-              -->
-              <additionalparam>${javadoc.additional.params}</additionalparam>
               <additionalOptions>${javadoc.additional.params}</additionalOptions>
             </configuration>
           </plugin>


### PR DESCRIPTION
…h has been ignored since 3.0.0 from 2017. [1] 

Fixes warnings when building Javadoc: [WARNING] Parameter 'additionalparam' is unknown for plugin 'maven-javadoc-plugin:3.6.3:javadoc (default-cli)'

I hope 7 years has been enough time for people to adapt their projects.

[1] https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-javadoc-plugin