### PR TITLE
Check for a file to disable testing a specific Java level if the prop…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           git status
           mvn -B -ntp versions:update-parent -DallowSnapshots=true -N
           git diff pom.xml
-          mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}} -Dmaven.compiler.release=17
+          mvn -B -ntp install -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}} -Dmaven.compiler.release=17
 
       - name: Test WildFly Common for no regression of #253
         run: |
@@ -60,7 +60,7 @@ jobs:
           git status
           mvn -B -ntp versions:update-parent -DallowSnapshots=true -N
           git diff pom.xml
-          mvn -B -ntp package install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}} -Dmaven.compiler.release=17
+          mvn -B -ntp package install -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}} -Dmaven.compiler.release=17
 
       - name: Check out WildFly Maven Plugin
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,12 +63,14 @@ jobs:
           mvn -B -ntp package install -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}} -Dmaven.compiler.release=17
 
       - name: Check out WildFly Maven Plugin
+        if: always()
         uses: actions/checkout@v4
         with:
           repository: wildfly/wildfly-maven-plugin
           path: wildfly-maven-plugin
 
       - name: Test WildFly Maven Plugin with updated parent
+        if: always()
         run: |
           cd wildfly-maven-plugin
           find . -name "build-release*" | xargs rm -rfv
@@ -78,12 +80,14 @@ jobs:
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
 
       - name: Check out JBoss Modules
+        if: always()
         uses: actions/checkout@v4
         with:
           repository: jboss-modules/jboss-modules
           path: jboss-modules
 
       - name: Test JBoss Modules with updated parent
+        if: always()
         run: |
           cd jboss-modules
           find . -name "build-release*" | xargs rm -rfv
@@ -93,12 +97,14 @@ jobs:
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
 
       - name: Check out JBoss Marshalling
+        if: always()
         uses: actions/checkout@v4
         with:
           repository: jboss-remoting/jboss-marshalling
           path: jboss-marshalling
 
       - name: Test JBoss Marshalling with updated parent
+        if: always()
         run: |
           cd jboss-marshalling
           find . -name "build-release*" | xargs rm -rfv
@@ -108,12 +114,14 @@ jobs:
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
 
       - name: Check out JBoss Logging Dev Tools
+        if: always()
         uses: actions/checkout@v4
         with:
           repository: jboss-logging/logging-dev-tools
           path: logging-dev-tools
 
       - name: Prepare for testing logging projects with updated parent
+        if: always()
         run: |
           cd logging-dev-tools
           find . -name "build-release*" | xargs rm -rfv
@@ -123,12 +131,14 @@ jobs:
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
 
       - name: Check out JBoss LogManager
+        if: always()
         uses: actions/checkout@v4
         with:
           repository: jboss-logging/jboss-logmanager
           path: jboss-logmanager
 
       - name: Test JBoss LogManager with updated parents
+        if: always()
         run: |
           cd jboss-logmanager
           find . -name "build-release*" | xargs rm -rfv
@@ -138,12 +148,14 @@ jobs:
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
 
       - name: Check out JBoss Logging
+        if: always()
         uses: actions/checkout@v4
         with:
           repository: jboss-logging/jboss-logging
           path: jboss-logging
 
       - name: Test JBoss Logging with updated parents
+        if: always()
         run: |
           cd jboss-logging
           find . -name "build-release*" | xargs rm -rfv
@@ -153,12 +165,14 @@ jobs:
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
 
       - name: Check out JBoss Logging Tools
+        if: always()
         uses: actions/checkout@v4
         with:
           repository: jboss-logging/jboss-logging-tools
           path: jboss-logging-tools
 
       - name: Test JBoss Logging Tools with updated parents
+        if: always()
         run: |
           cd jboss-logging-tools
           find . -name "build-release*" | xargs rm -rfv
@@ -168,12 +182,14 @@ jobs:
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
 
       - name: Check out Log4j2 to JBoss LogManager bridge
+        if: always()
         uses: actions/checkout@v4
         with:
           repository: jboss-logging/log4j2-jboss-logmanager
           path: log4j2-jboss-logmanager
 
       - name: Test Log4j2 to JBoss LogManager bridge with updated parents
+        if: always()
         run: |
           cd log4j2-jboss-logmanager
           find . -name "build-release*" | xargs rm -rfv

--- a/README.adoc
+++ b/README.adoc
@@ -171,7 +171,7 @@ In order to simplify development, it is recommended to project maintainers to se
 properties in your personal Maven `settings.xml` file.
 
 Extra unit tests are run for a given platform whenever a newer version than that platform
-was used to build the project and the appropriate control file is found (see <<build-control-files>>).
+was used to build the project and the appropriate control file is not found (see <<build-control-files>>).
 
 === Configuration
 
@@ -262,9 +262,9 @@ They do not need to have any content (i.e. they can be zero-sized).
 [cols="1m,2,1",options="header"]
 |===
 |File name|Purpose|Reference
-|build-test-java11|Run tests for Java 11 when `java11.home` is set and JDK 12 or later is used.|<<mr-jar-testing>>
-|build-test-java17|Run tests for Java 17 when `java17.home` is set and JDK 18 or later is used.|<<mr-jar-testing>>
-|build-test-java21|Run tests for Java 21 when `java21.home` is set and JDK 22 or later is used.|<<mr-jar-testing>>
+|disable-test-java11|Disables testing for Java 11 when `java11.home` is set and JDK 12 or later is used.|<<mr-jar-testing>>
+|disable-test-java17|Disables testing for Java 17 when `java17.home` is set and JDK 18 or later is used.|<<mr-jar-testing>>
+|disable-test-java21|Disables testing for Java 21 when `java21.home` is set and JDK 22 or later is used.|<<mr-jar-testing>>
 |===
 
 [id='where-to-get-more-information']

--- a/pom.xml
+++ b/pom.xml
@@ -894,7 +894,7 @@
                     <name>java11.home</name>
                 </property>
                 <file>
-                    <exists>${basedir}/build-test-java11</exists>
+                    <missing>${basedir}/disable-test-java11</missing>
                 </file>
             </activation>
             <build>
@@ -1192,7 +1192,7 @@
                     <name>java17.home</name>
                 </property>
                 <file>
-                    <exists>${basedir}/build-test-java17</exists>
+                    <missing>${basedir}/disable-test-java17</missing>
                 </file>
             </activation>
             <build>
@@ -1467,7 +1467,7 @@
                     <name>java21.home</name>
                 </property>
                 <file>
-                    <exists>${basedir}/build-test-java21</exists>
+                    <missing>${basedir}/disable-test-java21</missing>
                 </file>
             </activation>
             <build>


### PR DESCRIPTION
…erty is defined rather than looking for a file to enable the profile.

The idea here is to enable the test profiles by default if the `javaXX.home` property is set unless a `disable-test-javaXX` file is defined. This allows testing with different Java versions by default instead of having to add files to each module of a multi-module project when you want to test a new Java version.

resolves #416 