### PR TITLE
Update Surefire and Failsafe with a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 15
+    groups:
+      surefire:
+        patterns:
+          - org.apache.maven.plugins:maven-surefire-plugin
+          - org.apache.maven.plugins:maven-failsafe-plugin
+          - org.apache.maven.plugins:maven-surefire-report-plugin
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`


### PR DESCRIPTION
Presently, we get three dependabot PRs for Surefire, only one of which can be merged (because they all share the same property). This is annoying and might be fixable by combining the three Surefire dependencies into a group.