### PR TITLE
Set `javadoc` source level to match base layer version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -912,14 +912,9 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default</id>
-                                <configuration>
-                                    <source>11</source>
-                                </configuration>
-                            </execution>
-                        </executions>
+                        <configuration>
+                            <source>11</source>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -963,14 +958,9 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default</id>
-                                <configuration>
-                                    <source>17</source>
-                                </configuration>
-                            </execution>
-                        </executions>
+                        <configuration>
+                            <source>17</source>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -1014,14 +1004,9 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default</id>
-                                <configuration>
-                                    <source>21</source>
-                                </configuration>
-                            </execution>
-                        </executions>
+                      <configuration>
+                          <source>21</source>
+                      </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Fixes #409