### PR TITLE
[363] Drop the maven.compiler.argument.* properties as those are not …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,16 +47,20 @@ jobs:
       - name: Test WildFly Common with updated parent
         run: |
           cd wildfly-common
+          find . -name "build-release*" | xargs rm -rfv
+          git status
           mvn -B -ntp versions:update-parent -DallowSnapshots=true -N
           git diff pom.xml
-          mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
+          mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}} -Dmaven.compiler.release=17
 
       - name: Test WildFly Common for no regression of #253
         run: |
           cd wildfly-common
+          find . -name "build-release*" | xargs rm -rfv
+          git status
           mvn -B -ntp versions:update-parent -DallowSnapshots=true -N
           git diff pom.xml
-          mvn -B -ntp package install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
+          mvn -B -ntp package install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}} -Dmaven.compiler.release=17
 
       - name: Check out WildFly Maven Plugin
         uses: actions/checkout@v4
@@ -67,6 +71,8 @@ jobs:
       - name: Test WildFly Maven Plugin with updated parent
         run: |
           cd wildfly-maven-plugin
+          find . -name "build-release*" | xargs rm -rfv
+          git status
           mvn -B -ntp versions:update-parent -DallowSnapshots=true -N
           git diff pom.xml
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
@@ -80,6 +86,8 @@ jobs:
       - name: Test JBoss Modules with updated parent
         run: |
           cd jboss-modules
+          find . -name "build-release*" | xargs rm -rfv
+          git status
           mvn -B -ntp versions:update-parent -DallowSnapshots=true -N
           git diff pom.xml
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
@@ -93,6 +101,8 @@ jobs:
       - name: Test JBoss Marshalling with updated parent
         run: |
           cd jboss-marshalling
+          find . -name "build-release*" | xargs rm -rfv
+          git status
           mvn -B -ntp versions:update-parent -DallowSnapshots=true -N
           git diff pom.xml
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
@@ -106,6 +116,8 @@ jobs:
       - name: Prepare for testing logging projects with updated parent
         run: |
           cd logging-dev-tools
+          find . -name "build-release*" | xargs rm -rfv
+          git status
           mvn -B -ntp versions:update-parent -DallowSnapshots=true -N
           git diff pom.xml
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
@@ -119,6 +131,8 @@ jobs:
       - name: Test JBoss LogManager with updated parents
         run: |
           cd jboss-logmanager
+          find . -name "build-release*" | xargs rm -rfv
+          git status
           mvn -B -ntp versions:update-parent -DallowSnapshots=true -N
           git diff pom.xml
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
@@ -132,6 +146,8 @@ jobs:
       - name: Test JBoss Logging with updated parents
         run: |
           cd jboss-logging
+          find . -name "build-release*" | xargs rm -rfv
+          git status
           mvn -B -ntp versions:update-parent -DallowSnapshots=true -N
           git diff pom.xml
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
@@ -145,6 +161,8 @@ jobs:
       - name: Test JBoss Logging Tools with updated parents
         run: |
           cd jboss-logging-tools
+          find . -name "build-release*" | xargs rm -rfv
+          git status
           mvn -B -ntp versions:update-parent -DallowSnapshots=true -N
           git diff pom.xml
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}
@@ -158,6 +176,8 @@ jobs:
       - name: Test Log4j2 to JBoss LogManager bridge with updated parents
         run: |
           cd log4j2-jboss-logmanager
+          find . -name "build-release*" | xargs rm -rfv
+          git status
           mvn -B -ntp versions:update-parent -DallowSnapshots=true -N
           git diff pom.xml
           mvn -B -ntp install -Djava11.home=${{env.JAVA_HOME_11_X64}} -Djava17.home=${{env.JAVA_HOME_17_X64}} -Djava21.home=${{env.JAVA_HOME_21_X64}}

--- a/README.adoc
+++ b/README.adoc
@@ -45,16 +45,28 @@ be customized. For example, to override the default version of the
 </properties>
 ----
 
-Or override the default Java compiler source and target level used in
-the build. Note the default level is 11. Also note that the preferred way to set the source/target version for compilation is to use one of the `build-release-XXX` <<build-control-files,control files>> instead, which will set the `javac` `--release` flag to the corresponding version.
+Or override the default Java compiler release level used in the build. This uses the `javac --release` argument to compile
+for the specified Java SE release. Note the default level is 11.
 
 [source,xml]
 ----
 <properties>
-  <maven.compiler.target>17</maven.compiler.target>
-  <maven.compiler.source>17</maven.compiler.source>
+  <maven.compiler.release>17</maven.compiler.release>
 </properties>
 ----
+
+If you need tests compiled at a different level, you can use the `maven.compiler.testRelease` property. This defaults
+to the `maven.compiler.release` property.
+
+[source,xml]
+----
+<properties>
+  <maven.compiler.testRelease>21</maven.compiler.testRelease>
+</properties>
+----
+
+NOTE: If you're compiling down to Java 1.8, you can still use the `maven.compiler.release` property. Simply set the
+value to `1.8` and it the appropriate settings will be configured.
 
 The minimum version of Java or Maven required to run a build can also be
 set via properties.
@@ -67,7 +79,7 @@ set via properties.
 </properties>
 ----
 
-If `jdk.min.version` is not set, it defaults to the version defined by the `maven.compiler.source` property.
+If `jdk.min.version` is not set, it defaults to the version defined by the `maven.compiler.release` property.
 
 For the full list of properties, refer to the POM itself.
 
@@ -171,25 +183,8 @@ To configure a multi-release JAR, you need the following pieces of information:
 [id='mr-jar-base-layer']
 ==== Step 1: Base layer version
 
-Choose your base layer version.  This can be Java 11 or anything later.  Configure the version by configuring the
-`release` property in the `default-compile` execution of `maven-compiler-plugin`:
-
-[source,xml]
-----
-<plugin>
-  <artifactId>maven-compiler-plugin</artifactId>
-  <executions>
-    <execution>
-      <id>default-compile</id>
-      <configuration>
-        <release>17</release>
-      </configuration>
-    </execution>
-  </executions>
-</plugin>
-----
-
-If the `build-release-11`, `build-release-17`, or `build-release-21` file is present in the root of your project, then this step is automatically done for you. Only one such file should be present.
+Choose your base layer version. This can be Java 11 or anything later. Set the `maven.compiler.release` property to
+your desired version and this will configure the `maven-compiler-plugin` with the release version.
 
 [id='mr-jar-highest-layer']
 ==== Step 2: Highest layer version
@@ -267,9 +262,6 @@ They do not need to have any content (i.e. they can be zero-sized).
 [cols="1m,2,1",options="header"]
 |===
 |File name|Purpose|Reference
-|build-release-11|Use the `<release>` option to set Java 11 for the base layer.|<<mr-jar-base-layer>>
-|build-release-17|Use the `<release>` option to set Java 17 for the base layer.|<<mr-jar-base-layer>>
-|build-release-21|Use the `<release>` option to set Java 21 for the base layer.|<<mr-jar-base-layer>>
 |build-test-java11|Run tests for Java 11 when `java11.home` is set and JDK 12 or later is used.|<<mr-jar-testing>>
 |build-test-java17|Run tests for Java 17 when `java17.home` is set and JDK 18 or later is used.|<<mr-jar-testing>>
 |build-test-java21|Run tests for Java 21 when `java21.home` is set and JDK 22 or later is used.|<<mr-jar-testing>>

--- a/pom.xml
+++ b/pom.xml
@@ -157,30 +157,23 @@
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
       <!-- maven-compiler-plugin -->
-      <maven.compiler.target>11</maven.compiler.target>
-      <maven.compiler.source>11</maven.compiler.source>
-      <maven.compiler.testTarget>${maven.compiler.target}</maven.compiler.testTarget>
-      <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>
-
-      <!--
-          Options to override the compiler arguments directly on the compiler argument line to separate between what
-          the IDE understands as the source level and what the Maven compiler actually use.
-      -->
-      <maven.compiler.argument.target>${maven.compiler.target}</maven.compiler.argument.target>
-      <maven.compiler.argument.source>${maven.compiler.source}</maven.compiler.argument.source>
-      <maven.compiler.argument.testTarget>${maven.compiler.testTarget}</maven.compiler.argument.testTarget>
-      <maven.compiler.argument.testSource>${maven.compiler.testSource}</maven.compiler.argument.testSource>
+      <maven.compiler.release>11</maven.compiler.release>
+      <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+      <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+      <maven.compiler.testRelease>${maven.compiler.release}</maven.compiler.testRelease>
+      <maven.compiler.testTarget>${maven.compiler.testRelease}</maven.compiler.testTarget>
+      <maven.compiler.testSource>${maven.compiler.testRelease}</maven.compiler.testSource>
 
       <!-- maven-enforcer-plugin -->
       <maven.min.version>3.6.2</maven.min.version>
-      <jdk.min.version>${maven.compiler.argument.source}</jdk.min.version>
+      <jdk.min.version>${maven.compiler.release}</jdk.min.version>
       <insecure.repositories>ERROR</insecure.repositories>
 
       <!-- maven-idea-plugin & maven-eclipse-plugin -->
       <downloadSources>true</downloadSources>
 
       <!-- maven-pmd-plugin -->
-      <targetJdk>${maven.compiler.argument.target}</targetJdk>
+      <targetJdk>${maven.compiler.release}</targetJdk>
 
       <!-- maven-release-plugin -->
       <useReleaseProfile>false</useReleaseProfile>
@@ -322,10 +315,6 @@
             <configuration>
               <showDeprecation>true</showDeprecation>
               <showWarnings>true</showWarnings>
-              <source>${maven.compiler.argument.source}</source>
-              <target>${maven.compiler.argument.target}</target>
-              <testSource>${maven.compiler.argument.testSource}</testSource>
-              <testTarget>${maven.compiler.argument.testTarget}</testTarget>
               <compilerArgs>
                 <arg>-Xlint:unchecked</arg>
               </compilerArgs>
@@ -739,6 +728,25 @@
                 </rules>
               </configuration>
             </execution>
+            <execution>
+              <id>enforce-no-release-files</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireFilesDontExist>
+                    <files>
+                      <file>${basedir}/build-release-11</file>
+                      <file>${basedir}/build-release-17</file>
+                      <file>${basedir}/build-release-21</file>
+                    </files>
+                    <message>Please remove the build-release-* file and add the maven.compiler.release property to your the properties in your pom.xml.</message>
+                  </requireFilesDontExist>
+                </rules>
+                <fail>true</fail>
+              </configuration>
+            </execution>
           </executions>
         </plugin>
 
@@ -876,146 +884,6 @@
       </profile>
 
         <!-- MR JAR support begins here -->
-
-        <!-- Release flags -->
-
-        <profile>
-            <id>compile-java11-release-flag</id>
-            <activation>
-                <file>
-                    <exists>${basedir}/build-release-11</exists>
-                </file>
-                <jdk>[11,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-compile</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>compile</goal>
-                                </goals>
-                                <configuration>
-                                    <release>11</release>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>default-testCompile</id>
-                                <phase>test-compile</phase>
-                                <goals>
-                                    <goal>testCompile</goal>
-                                </goals>
-                                <configuration>
-                                    <release>11</release>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <source>11</source>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>compile-java17-release-flag</id>
-            <activation>
-                <file>
-                    <exists>${basedir}/build-release-17</exists>
-                </file>
-                <jdk>[17,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-compile</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>compile</goal>
-                                </goals>
-                                <configuration>
-                                    <release>17</release>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>default-testCompile</id>
-                                <phase>test-compile</phase>
-                                <goals>
-                                    <goal>testCompile</goal>
-                                </goals>
-                                <configuration>
-                                    <release>17</release>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <source>17</source>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>compile-java21-release-flag</id>
-            <activation>
-                <file>
-                    <exists>${basedir}/build-release-21</exists>
-                </file>
-                <jdk>[21,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-compile</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>compile</goal>
-                                </goals>
-                                <configuration>
-                                    <release>21</release>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>default-testCompile</id>
-                                <phase>test-compile</phase>
-                                <goals>
-                                    <goal>testCompile</goal>
-                                </goals>
-                                <configuration>
-                                    <release>21</release>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                      <configuration>
-                          <source>21</source>
-                      </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
 
         <!-- This profile is activated when Java 12 or later is used to test a project that supports Java 11 -->
         <profile>


### PR DESCRIPTION
…defined in the maven-compiler-plugin. Favor the maven.compiler.release property over using the <release> setting.

resolves #363 