### PR TITLE
docs: Fix readme in regard to compilation down to JDK 8.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,8 +65,8 @@ to the `maven.compiler.release` property.
 </properties>
 ----
 
-NOTE: If you're compiling down to Java 1.8, you can still use the `maven.compiler.release` property. Simply set the
-value to `1.8` and it the appropriate settings will be configured.
+NOTE: If you're compiling down to Java 8, you can still use the `maven.compiler.release` property. Simply set the
+value to `8` and it the appropriate settings will be configured.
 
 The minimum version of Java or Maven required to run a build can also be
 set via properties.


### PR DESCRIPTION
Reference
https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html 
https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html

n.b. 

> You have to set the version following [Java's new Version-String Scheme (JEP 223)](https://openjdk.org/jeps/223).

so, 1.8 produces

> Fatal error compiling: error: release version 1.8 not supported -> [Help 1]