### PR TITLE
Add support for download-maven-plugin v2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
       <version.dependency.plugin>3.9.0</version.dependency.plugin>
       <version.deploy.plugin>3.1.4</version.deploy.plugin>
       <version.download.plugin>1.13.0</version.download.plugin>
+      <version.download2.plugin>2.0.0</version.download2.plugin>
       <version.ear.plugin>3.4.0</version.ear.plugin>
       <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
       <version.ejb.plugin>3.2.1</version.ejb.plugin>
@@ -252,6 +253,12 @@
             <groupId>com.googlecode.maven-download-plugin</groupId>
             <artifactId>download-maven-plugin</artifactId>
             <version>${version.download.plugin}</version>
+          </plugin>
+          <!-- groupId change: keep the above until everyone upgrades to v2 -->
+          <plugin>
+            <groupId>io.github.download-maven-plugin</groupId>
+            <artifactId>download-maven-plugin</artifactId>
+            <version>${version.download2.plugin}</version>
           </plugin>
           <plugin>
             <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
Version 2.0.0 of the download-maven-plugin has moved to a new groupId (io.github.download-maven-plugin) Adds the new plugin definition while maintaining the old one for backward compatibility