### PR TITLE
[#550] Name central deployment after the reactor root project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,8 @@
       <central.autoPublish>true</central.autoPublish>
       <central.waitUntil>validated</central.waitUntil>
       <central.skipPublishing>false</central.skipPublishing>
-      <central.deploymentName>${project.artifactId}-${project.version}</central.deploymentName>
+      <!-- Name the deployment after the reactor root, not the last-built module (${project.artifactId}). -->
+      <central.deploymentName>${session.topLevelProject.artifactId}-${session.topLevelProject.version}</central.deploymentName>
 
       <!-- ************** -->
       <!-- Build settings -->


### PR DESCRIPTION
The publishing goal binds to the last reactor module's deploy phase, so ${project.artifactId} named the deployment after an arbitrary module. Use ${session.topLevelProject.*} so multi-module deploys are named after the aggregator instead.

https://github.com/jboss/jboss-parent-pom/issues/550